### PR TITLE
Made 'Call' more robust as to work in a broader range of environments

### DIFF
--- a/R/apriori.R
+++ b/R/apriori.R
@@ -53,7 +53,7 @@ apriori <-  function(data, parameter = NULL, appearance = NULL, control = NULL)
     }
 
     ## call apriori
-    result <- .Call(R_rapriori, 
+    result <- .Call("R_rapriori", 
         ## transactions
         items@p,
         items@i,
@@ -61,7 +61,8 @@ apriori <-  function(data, parameter = NULL, appearance = NULL, control = NULL)
         ## parameter
         parameter, control,
         appearance,
-        data@itemInfo)                  
+        data@itemInfo, 
+        PACKAGE = "arules")                  
 
     ## add some reflectance
     call <- match.call()

--- a/R/crossTable.R
+++ b/R/crossTable.R
@@ -29,7 +29,7 @@ setMethod("crossTable", signature(x = "itemMatrix"),
     
     measure <- match.arg(measure)
     
-    m <- .Call(R_crosstab_ngCMatrix, x@data, NULL, TRUE)
+    m <- .Call("R_crosstab_ngCMatrix", x@data, NULL, TRUE, PACKAGE = "arules")
     if (is.null(dimnames(m)))
       dimnames(m) <- list(itemLabels(x), itemLabels(x))
     

--- a/R/eclat.R
+++ b/R/eclat.R
@@ -59,14 +59,15 @@ eclat <-  function(data, parameter = NULL, control = NULL)
     }
 
     ## call eclat
-    result <- .Call(R_reclat, 
+    result <- .Call("R_reclat", 
         ## transactions
         items@p,
         items@i,
         items@Dim,
         ## parameter
         parameter, control,
-        data@itemInfo)                  
+        data@itemInfo,
+        PACKAGE = "arules")                  
     
     ## validate sparse Matrix (this takes care of sorting vector i)
     validObject(result@items@data)

--- a/R/interestMeasures.R
+++ b/R/interestMeasures.R
@@ -313,14 +313,14 @@ setMethod("interestMeasure",  signature(x = "rules"),
   imp <- numeric(length(x))
   
   ### do it by unique rhs
-  rr <- .Call(R_pnindex, rhs(x)@data, NULL, FALSE)
+  rr <- .Call("R_pnindex", rhs(x)@data, NULL, FALSE, PACKAGE = "arules")
   
   for(r in unique(rr)) {
     pos <- which(rr==r) 
     
     q2 <- q[pos]
     ### FALSE is for verbose
-    qsubmax <- .Call(R_pnmax, lhs(x[pos])@data, q2, FALSE)
+    qsubmax <- .Call("R_pnmax", lhs(x[pos])@data, q2, FALSE, PACKAGE = "arules")
   
     imp[pos] <- q2 - qsubmax
   }

--- a/R/is.closed.R
+++ b/R/is.closed.R
@@ -50,5 +50,5 @@ setMethod("is.closed", signature(x = "itemsets"),
             cnt <- as.integer(round(supp * ntrans))
         }
             
-        .Call(R_pnclosed, x@items@data, as.integer(cnt), FALSE)
+        .Call("R_pnclosed", x@items@data, as.integer(cnt), FALSE, PACKAGE = "arules")
     })

--- a/R/is.maximal.R
+++ b/R/is.maximal.R
@@ -24,7 +24,7 @@ setMethod("is.maximal", signature(x = "itemMatrix"),
     function(x) {
         ## 
         u <- unique(x)
-        m <- .Call(R_pncount, u@data, u@data, TRUE, TRUE, FALSE) == 1
+        m <- .Call("R_pncount", u@data, u@data, TRUE, TRUE, FALSE, PACKAGE = "arules") == 1
         i <- match(x, u)
         m[i]
 })

--- a/R/is.superset.R
+++ b/R/is.superset.R
@@ -51,8 +51,8 @@ setMethod("is.subset", signature(x = "itemMatrix"),
 
     if(sparse) return(.is.subset_sparse(x, y, proper))
 
-    if (is.null(y)) m <- .Call(R_crosstab_ngCMatrix, x@data, NULL, FALSE)
-    else m <- .Call(R_crosstab_ngCMatrix, x@data, y@data, FALSE)
+    if (is.null(y)) m <- .Call("R_crosstab_ngCMatrix", x@data, NULL, FALSE, PACKAGE = "arules")
+    else m <- .Call("R_crosstab_ngCMatrix", x@data, y@data, FALSE, PACKAGE = "arules")
 
     m <- m == size(x)
 
@@ -81,7 +81,7 @@ setMethod("is.subset", signature(x = "associations"),
   if(is.null(y)) y <- x
 
   p <- as.integer(rep(0, x@data@Dim[2]+1))
-  i <- .Call(R_is_subset, x@data@p, x@data@i, x@data@Dim, 
+  i <- .Call("R_is_subset", x@data@p, x@data@i, x@data@Dim, 
     y@data@p, y@data@i, y@data@Dim, 
     as.logical(proper), p, PACKAGE = "arules")
 

--- a/R/itemCoding.R
+++ b/R/itemCoding.R
@@ -114,7 +114,7 @@ setMethod("recode", signature(x = "itemMatrix"),
 
         ## recode items
         if (any(k != seq(length(k))))
-            x@data <- .Call(R_recode_ngCMatrix, x@data, k)
+            x@data <- .Call("R_recode_ngCMatrix", x@data, k, PACKAGE = "arules")
 
         ## enlarge
         if (x@data@Dim[1] <  length(itemLabels))

--- a/R/itemFrequency.R
+++ b/R/itemFrequency.R
@@ -37,14 +37,14 @@ setMethod("itemFrequency", signature(x = "itemMatrix"),
         stop("transactions do not contain weights. Add a weight column to transactionInfo.")
       
       weight <- as.numeric(transactionInfo(x)[["weight"]])
-      support <- .Call(R_rowWSums_ngCMatrix, x@data, weight)
+      support <- .Call("R_rowWSums_ngCMatrix", x@data, weight, PACKAGE = "arules")
       total <- sum(weight)
       
     }else {
       ## we could also use rowSums
       ##support <- tabulate(x@data@i + 1L, nbins = x@data@Dim[1])
       
-      support <- .Call(R_rowSums_ngCMatrix, x@data)
+      support <- .Call("R_rowSums_ngCMatrix", x@data, PACKAGE = "arules")
       total <- length(x)
     }
     

--- a/R/itemMatrix.R
+++ b/R/itemMatrix.R
@@ -46,7 +46,7 @@ setMethod("size", signature(x = "itemMatrix"),
     ## diff(x@data@p) is nearly as fast as colSums(x@data).
     
     ## FIXME: Add transactionID or itemsetID as names
-    cnt <- .Call(R_colSums_ngCMatrix, x@data)
+    cnt <- .Call("R_colSums_ngCMatrix", x@data, PACKAGE = "arules")
     cnt
   }
 )
@@ -134,11 +134,11 @@ setAs("itemMatrix", "list",
 setMethod("LIST", signature(from = "itemMatrix"),
   function(from, decode = TRUE) {
     if (decode) {
-      to <- .Call(R_asList_ngCMatrix, from@data, itemLabels(from))
+      to <- .Call("R_asList_ngCMatrix", from@data, itemLabels(from), PACKAGE = "arules")
       names(to) <- itemsetInfo(from)[["itemsetID"]]
       to
     } else
-      .Call(R_asList_ngCMatrix, from@data, NULL)
+      .Call("R_asList_ngCMatrix", from@data, NULL, PACKAGE = "arules")
   }
 )
 
@@ -291,7 +291,7 @@ setMethod("[", signature(x = "itemMatrix", i = "ANY", j = "ANY", drop = "ANY"),
       
       i <- .translate_index(i, rownames(x), nrow(x))
       ## faster than: x@data <- x@data[,i, drop=FALSE]
-      x@data <- .Call(R_colSubset_ngCMatrix, x@data, i)
+      x@data <- .Call("R_colSubset_ngCMatrix", x@data, i, PACKAGE = "arules")
       
       ### only subset if we have rows
       if(nrow(x@itemsetInfo)) x@itemsetInfo <- x@itemsetInfo[i,, drop = FALSE]
@@ -311,7 +311,7 @@ setMethod("[", signature(x = "itemMatrix", i = "ANY", j = "ANY", drop = "ANY"),
       
       j <- .translate_index(j, colnames(x), ncol(x))
       ## faster than: x@data <- x@data[j,, drop=FALSE]
-      x@data <- .Call(R_rowSubset_ngCMatrix, x@data, j)
+      x@data <- .Call("R_rowSubset_ngCMatrix", x@data, j, PACKAGE = "arules")
         
       x@itemInfo <- x@itemInfo[j,, drop = FALSE]
     }
@@ -341,12 +341,12 @@ setMethod("c", signature(x = "itemMatrix"),
           y@itemInfo[n,, drop = FALSE])
       }
       if (any(k != seq_len(length(k))))
-        y@data <- .Call(R_recode_ngCMatrix, y@data, k)
+        y@data <- .Call("R_recode_ngCMatrix", y@data, k, PACKAGE = "arules")
       if (y@data@Dim[1] <  x@data@Dim[1])
         y@data@Dim[1] <- x@data@Dim[1]
       
       ## this is faste than x@data <- cbind(x@data, y@data)
-      x@data <- .Call(R_cbind_ngCMatrix, x@data, y@data)
+      x@data <- .Call("R_cbind_ngCMatrix", x@data, y@data, PACKAGE = "arules")
     }
     validObject(x, complete = TRUE)
     x
@@ -360,7 +360,7 @@ setMethod("merge", signature(x="itemMatrix"),
     if(nrow(x)!=nrow(y)) stop("The number of rows in x and y do not conform!")
     
     ## this is faster than dc <- rbind(x@data, y@data) 
-    dc <- t(.Call(R_cbind_ngCMatrix, t(x@data), t(y@data)))
+    dc <- t(.Call("R_cbind_ngCMatrix", t(x@data), t(y@data), PACKAGE = "arules"))
     
     ## fix itemInfo
     iix <- itemInfo(x)
@@ -383,7 +383,7 @@ setMethod("merge", signature(x="itemMatrix"),
 setMethod("duplicated", signature(x = "itemMatrix"),
   function(x, incomparables = FALSE) {
     ## use a prefix tree
-    i <- .Call(R_pnindex, x@data, NULL, FALSE)
+    i <- .Call("R_pnindex", x@data, NULL, FALSE, PACKAGE = "arules")
     duplicated(i)
   }
 )
@@ -403,10 +403,10 @@ setMethod("match", signature(x = "itemMatrix", table = "itemMatrix"),
       table@data@Dim[1] <- table@data@Dim[1] + length(n)
     }
     if (any(k != seq_len(length(k))))
-      x@data <- .Call(R_recode_ngCMatrix, x@data, k)
+      x@data <- .Call("R_recode_ngCMatrix", x@data, k, PACKAGE = "arules")
     if (x@data@Dim[1] <  table@data@Dim[1])
       x@data@Dim[1] <- table@data@Dim[1]
-    i <- .Call(R_pnindex, table@data, x@data, FALSE)
+    i <- .Call("R_pnindex", table@data, x@data, FALSE, PACKAGE = "arules")
     match(i, seq_len(length(table)), nomatch = nomatch, 
       incomparables = incomparables)
   }

--- a/R/ruleInduction.R
+++ b/R/ruleInduction.R
@@ -180,7 +180,7 @@ ruleInduction.apriori <- function(x, transactions, confidence = 0.8,
 
 ruleInduction.tidlists <- function(x, transactions, confidence = 0.8, verbose = FALSE) {
     tid <- as(transactions, "tidLists")
-    data <- .Call(R_tid_rules ,tid@data, x@items@data)
+    data <- .Call("R_tid_rules" ,tid@data, x@items@data, PACKAGE = "arules")
     names(data) <- c("support", "confidence",
         "lhs_i", "lhs_p", "rhs_i", "rhs_p", "Dim")
 
@@ -202,7 +202,7 @@ ruleInduction.tidlists <- function(x, transactions, confidence = 0.8, verbose = 
 
 ruleInduction.ptree <- 
 function(x, transactions, confidence = 0.8, reduce = FALSE, verbose = FALSE) {
-    r <- .Call(R_pncount, x@items@data, transactions@data, FALSE, reduce, verbose)
+    r <- .Call("R_pncount", x@items@data, transactions@data, FALSE, reduce, verbose, PACKAGE = "arules")
     
     names(r) <- c("data.lhs","data.rhs","support","confidence","lift", "itemset")
     
@@ -228,7 +228,7 @@ function(x, confidence = 0.8, verbose = FALSE) {
     if (is.null(quality(x)$support))
         stop("cannot induce rules because support is missing! Specify transactions.")
 
-    r <- data.frame(.Call(R_pnrindex, x@items@data, verbose))
+    r <- data.frame(.Call("R_pnrindex", x@items@data, verbose, PACKAGE = "arules"))
     names(r) <- c("i", "li", "ri")
 
     if (!all(r$li) || !all(r$ri))

--- a/R/support.R
+++ b/R/support.R
@@ -58,7 +58,7 @@ setMethod("support", signature(x = "itemMatrix"),
     }
     if (any(k != seq_len(length(k))))
       transactions@data <-
-      .Call(R_recode_ngCMatrix, transactions@data, k)
+      .Call("R_recode_ngCMatrix", transactions@data, k, PACKAGE = "arules")
     if (transactions@data@Dim[1] <  x@data@Dim[1])
       transactions@data@Dim[1] <- x@data@Dim[1]
     
@@ -116,7 +116,7 @@ support.tidlists <- function(x, transactions, control = NULL) {
   
   tid <- as(transactions, "tidLists")
   
-  support <- .Call(R_tid_support ,tid@data, x@data)
+  support <- .Call("R_tid_support" ,tid@data, x@data, PACKAGE = "arules")
   
   #names(supports) <- labels(x)
   support
@@ -126,17 +126,17 @@ support.ptree <- function(x, transactions, control = NULL) {
   reduce  <- if(is.null(control$r))    FALSE else control$r
   verbose <- if(is.null(control$v))    FALSE else control$v
   
-  .Call(R_pncount, x@data, transactions@data, TRUE, reduce, verbose)
+  .Call("R_pncount", x@data, transactions@data, TRUE, reduce, verbose, PACKAGE = "arules")
 }
       
 support.weighted <- function(x, transactions, control = NULL) {
   verbose <- if(is.null(control$v))    FALSE else control$v
   weights <- as.numeric(transactionInfo(transactions)[["weight"]])
   
-  .Call(R_wcount_ngCMatrix, x@data, 
+  .Call("R_wcount_ngCMatrix", x@data, 
     #t(transactions@data), 
     selectMethod("t", class(transactions@data))(transactions@data), 
-    weights, NULL, NULL, verbose)
+    weights, NULL, NULL, verbose, PACKAGE = "arules")
 }
 
 ## wrapper method for associations

--- a/R/tidLists.R
+++ b/R/tidLists.R
@@ -68,7 +68,7 @@ setMethod("length", signature(x = "tidLists"),
 
 ## produces a vector of element sizes
 setMethod("size", signature(x = "tidLists"),
-  function(x) .Call(R_colSums_ngCMatrix, x@data))
+  function(x) .Call("R_colSums_ngCMatrix", x@data, PACKAGE = "arules"))
 
 ##*******************************************************
 ## show/summary
@@ -143,7 +143,7 @@ setMethod("c", signature(x = "tidLists"),
       
       if(ncol(x) != ncol(y)) stop("transactions not conforming.")
       
-      dat <- .Call(R_cbind_ngCMatrix, dat, y@data)
+      dat <- .Call("R_cbind_ngCMatrix", dat, y@data, PACKAGE = "arules")
       itemI <- rbind(itemI, itemInfo(y))
     }
     
@@ -167,7 +167,7 @@ setMethod("[", signature(x = "tidLists", i = "ANY", j = "ANY", drop = "ANY"),
       } 
       
       i <- .translate_index(i, rownames(x), nrow(x)) 
-      x@data <- .Call(R_colSubset_ngCMatrix, x@data, i)
+      x@data <- .Call("R_colSubset_ngCMatrix", x@data, i, PACKAGE = "arules")
       
       x@itemInfo <- x@itemInfo[i,, drop = FALSE]
     }
@@ -180,7 +180,7 @@ setMethod("[", signature(x = "tidLists", i = "ANY", j = "ANY", drop = "ANY"),
       } 
       
       j <- .translate_index(j, colnames(x), ncol(x))
-      x@data <- .Call(R_rowSubset_ngCMatrix, x@data, j)
+      x@data <- .Call("R_rowSubset_ngCMatrix", x@data, j, PACKAGE = "arules")
       
       x@transactionInfo <- x@transactionInfo[j,, drop = FALSE]
     }
@@ -202,11 +202,11 @@ setMethod("LIST", signature(from = "tidLists"),
       i <- from@transactionInfo[["transactionID"]]
       if (!is.null(i))
         i <- as.character(i)
-      to <- .Call(R_asList_ngCMatrix, from@data, i)
+      to <- .Call("R_asList_ngCMatrix", from@data, i, PACKAGE = "arules")
       names(to) <- from@itemInfo[["labels"]]
       to
     } else
-      .Call(R_asList_ngCMatrix, from@data, NULL)
+      .Call("R_asList_ngCMatrix", from@data, NULL, PACKAGE = "arules")
   }
 )
 

--- a/R/warm.R
+++ b/R/warm.R
@@ -28,7 +28,7 @@ hits <- function(data, iter = 16L, tol = NULL,
   data <- as(data, "transactions")
   type <- match.arg(type)
   
-  r <- .Call(R_hits_ngCMatrix, data@data, iter, tol, verbose)
+  r <- .Call("R_hits_ngCMatrix", data@data, iter, tol, verbose, PACKAGE = "arules")
   names(r) <- transactionInfo(data)[["transactionID"]]
   
   switch(type,
@@ -70,11 +70,12 @@ weclat <- function(data, parameter = NULL, control = NULL) {
   }
   ## r <- .Call(R_transpose_ngCMatrix, data@data)
   r <- selectMethod("t", class(data@data))(data@data)
-  r <- .Call(R_weclat_ngCMatrix, r, weight,
+  r <- .Call("R_weclat_ngCMatrix", r, weight,
     parameter@support,
     parameter@minlen,
     parameter@maxlen,
-    control@verbose)
+    control@verbose,
+    PACKAGE = "arules")
   names(r) <- c("data", "support")
   validObject(r$data)
   


### PR DESCRIPTION
Changed the .Call functions to include the PACKAGE parameter and changed the first parameter to a string. Without these changes the calls would cause errors e.g.: object R_rapriori not found.